### PR TITLE
Make Read() private

### DIFF
--- a/NGps/NmeaReceiver.cs
+++ b/NGps/NmeaReceiver.cs
@@ -228,7 +228,7 @@ namespace NGps
             }
         }
 
-        public void Read()
+        private void Read()
         {
             while (this.listening == 1)
             {


### PR DESCRIPTION
This was confusing until I looked at the source - I was expecting it to be a replacement for Listen(), but from what I can tell it doesn't function at all by itself. Access to this.listening is private, so therefore it cannot be used at all from the outside.